### PR TITLE
new rules in eslint-config-cat

### DIFF
--- a/packages/eslint-config-cat/src/__tests__/__ignore__/flowType.js
+++ b/packages/eslint-config-cat/src/__tests__/__ignore__/flowType.js
@@ -55,3 +55,15 @@ const requireReturnType = (argu: string) => argu;
  * @return {any} - any
  */
 const requireParameterType = (argu): string => argu;
+
+/**
+ * @example
+ * requireReturnType('test');
+ *
+ * @param {any} argu - any
+ * @return {Promise} - any
+ */
+const promiseIngore = (argu: string): Promise => new Promise((resolve, reject) => {
+  if (argu) resolve();
+  else reject();
+});

--- a/packages/eslint-config-cat/src/__tests__/__ignore__/import-1.js
+++ b/packages/eslint-config-cat/src/__tests__/__ignore__/import-1.js
@@ -12,8 +12,8 @@ import babel from '@babel/core/lib/index';
 // $expectError import/no-useless-path-segments
 import noUnresolver from './../index';
 
-// $expectError import/no-absolute-path
 // $expectError import/no-unresolved
+// $expectError import/no-absolute-path
 import noAbsolutePath from '/etc';
 
 // $expectError import/default
@@ -28,15 +28,11 @@ import noDuplicates from './import-3';
 
 fbjs();
 
-// $expectError import/no-self-import
 // $expectError import/first
 // $expectError import/newline-after-import
+// $expectError import/no-self-import
 import * as namespace from './import-1';
 fbjs();
-
-// $expectError import/exports-last
-// $expectError import/group-exports
-export const exportFirst = 'test';
 
 fbjs();
 
@@ -46,6 +42,7 @@ module2.test();
 // $expectError import/namespace
 namespace.test();
 
-// $expectError import/group-exports
 // $expectError import/no-mutable-exports
-export let exportSecond: string = 'test';
+export let exportLet: string = 'test';
+
+export default 'export default';

--- a/packages/eslint-config-cat/src/__tests__/__ignore__/jsDoc.js
+++ b/packages/eslint-config-cat/src/__tests__/__ignore__/jsDoc.js
@@ -91,10 +91,20 @@ const functionDeclarationRequiredJsDoc = (): number => 10;
 
 // $expectError require-jsdoc
 class classDeclarationRequiredJsDoc {
+  test = 'test';
+
   // $expectError require-jsdoc
   methodDefinitionRequiredJsdoc(): number {
     return 10;
   }
+
+  /**
+   * @example
+   * example.showInfo()
+   *
+   * @return {string} test
+  */
+  showInfo = (): string => this.test;
 }
 
 const testObj = {

--- a/packages/eslint-config-cat/src/__tests__/__ignore__/jsDoc.js
+++ b/packages/eslint-config-cat/src/__tests__/__ignore__/jsDoc.js
@@ -99,6 +99,9 @@ class classDeclarationRequiredJsDoc {
   }
 
   /**
+   * Use to test babel/no-invalid-this work.
+   * no-invalid-this will fail.
+   *
    * @example
    * example.showInfo()
    *

--- a/packages/eslint-config-cat/src/__tests__/eslint.js
+++ b/packages/eslint-config-cat/src/__tests__/eslint.js
@@ -111,6 +111,8 @@ describe('eslint', () => {
             case 'flowtype/no-flow-fix-me-comments':
             case 'flowtype/generic-spacing':
             case 'no-warning-comments':
+            case 'no-invalid-this':
+            case 'babel/no-invalid-this':
               return false;
             default:
               return true;

--- a/packages/eslint-config-cat/src/extendsConfigs.js
+++ b/packages/eslint-config-cat/src/extendsConfigs.js
@@ -29,6 +29,10 @@ export default {
       },
     ],
 
+    // FIXME: remove when eslint upgrade
+    'no-invalid-this': 'off',
+    'babel/no-invalid-this': 'error',
+
     'require-jsdoc': [
       'error',
       {

--- a/packages/eslint-config-cat/src/flowtype.js
+++ b/packages/eslint-config-cat/src/flowtype.js
@@ -14,8 +14,19 @@ export default {
     'flowtype/no-primitive-constructor-types': 'error',
     'flowtype/no-unused-expressions': 'error',
     'flowtype/no-weak-types': 'error',
-    'flowtype/require-parameter-type': 'error',
-    'flowtype/require-return-type': ['error', 'always'],
+    'flowtype/require-parameter-type': [
+      'error',
+      {
+        excludeParameterMatch: '^(resolve|reject)$',
+      },
+    ],
+    'flowtype/require-return-type': [
+      'error',
+      'always',
+      {
+        excludeMatching: ['Promise'],
+      },
+    ],
     'flowtype/require-valid-file-annotation': ['error', 'always'],
     'flowtype/require-variable-type': [
       'error',

--- a/packages/eslint-config-cat/src/import.js
+++ b/packages/eslint-config-cat/src/import.js
@@ -31,12 +31,10 @@ export default {
     'import/no-mutable-exports': 'error',
 
     'import/first': 'error',
-    'import/exports-last': 'error',
     'import/no-duplicates': 'error',
     'import/order': 'error',
     'import/newline-after-import': 'error',
     'import/prefer-default-export': 'error',
     'import/no-named-default': 'error',
-    'import/group-exports': 'error',
   },
 };


### PR DESCRIPTION
- Remove `import/group-exports` for `flowtype`

  ```js
  export type ...

  export default 'test';
  ```

- Remove `import/exports-last` for `flowtype`

  ```js
  export type ...

  const test = 'test';

  export default test;
  ```

- Ignore `Promise` of `flowtype/require-parameter-type`
- Ignore `Promise` of `flowtype/require-return-type`
- Fix `invalid-this` with `babel/no-invalid-this`

  ```js
  class {
    test = 'test';

    getTest () => this.test;
  }
  ```